### PR TITLE
updated blog url

### DIFF
--- a/page/_layout/nav.html
+++ b/page/_layout/nav.html
@@ -18,7 +18,7 @@
         {{for (s, n) in sections}}
         <li class="nav-item"><a class="nav-link" href="#{{fill s}}">{{fill n}}</a></li>
         {{end}}
-        <li class="nav-item"><a class="nav-link" href="/blog">Blog</a></li>
+        <li class="nav-item"><a class="nav-link" href="https://blog.algebraicjulia.org/">Blog</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
I checked the slides and all of our old links do work perfectly with redirecting to their new post location. Figured we can leave the slides untouched and only update the navigation stuff.